### PR TITLE
Fix bug in how noise scale is computed

### DIFF
--- a/fisher_experiment.py
+++ b/fisher_experiment.py
@@ -135,7 +135,7 @@ def main(args):
     stds = []
     for eta in args.etas:
         # Compute the Gaussian noise scale needed for eta:
-        scale = eta * etamax
+        scale = etamax / eta
         # Measure test accuracy:
         accuracy, std = compute_accuracy(
             model, test_data, noise_scale=scale, trials=args.trials,


### PR DESCRIPTION
Per Equation 15 in [the paper](https://arxiv.org/pdf/2102.11673.pdf), the relation between the noise parameter sigma (`scale`) and the spectral norm of the Jacobian (`eta_max`) should involve division by `eta`, not multiplication. Simply put: to guarantee a lower FIL, you need to add noise with a larger scale.

This corrects that mistake in the code.