### PR TITLE
Divide quadratic loss by two

### DIFF
--- a/models.py
+++ b/models.py
@@ -113,7 +113,7 @@ class LeastSquares:
         y = data["targets"].float()
         # [-1, 1] works much better for regression
         y[y == 0] = -1
-        return (X @ self.theta - y)**2
+        return (X @ self.theta - y)**2 / 2
 
     def influence_jacobian(self, data, weighted=True):
         """


### PR DESCRIPTION
To capture the description in the paper correctly, the quadratic loss in the least-squares model should be divided by two. This change does not change the Fisher information loss values in any way.